### PR TITLE
More portable  - Fixes https://github.com/McLeopold/gitlost/issues/2

### DIFF
--- a/bin/gitlost.js
+++ b/bin/gitlost.js
@@ -2,5 +2,5 @@
 var opn = require('opn');
 var server = require("../lib/server.js");
 
-opn('http://localhost:6776', {app: 'chrome'});
+opn('http://localhost:6776');
 server.listen(6776);

--- a/bin/gitlost.js
+++ b/bin/gitlost.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var opn = require('opn');
 var server = require("../lib/server.js");
 

--- a/web/client.js
+++ b/web/client.js
@@ -6,7 +6,7 @@ $(function () {
             settings.set('rankdir', $(this).val());
             get_graph();
         });
-    $("button[name=include_forward")
+    $("button[name=include_forward]")
         .click(function () {
             settings.set('include_forward', !$(this).hasClass('active'));
             get_graph();


### PR DESCRIPTION
The env "shebang" was step 1.

Step 2 is removing the specification of Chrome (which could have been considered a bit user-hostile to begin with.)

From https://github.com/sindresorhus/opn

> The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is google chrome on macOS, google-chrome on Linux and chrome on Windows.